### PR TITLE
fix: use stable keys for activity list

### DIFF
--- a/frontend/src/components/ProgressTracker.vue
+++ b/frontend/src/components/ProgressTracker.vue
@@ -449,7 +449,7 @@
       <div class="space-y-3 max-h-64 overflow-y-auto">
         <div
           v-for="(activity, index) in progress.recentActivities"
-          :key="`activity-${index}`"
+          :key="activity.id || activity.activity_id || activity.timestamp || index"
           class="flex items-start space-x-3 p-3 bg-gray-50 rounded-lg"
         >
           <div class="flex-shrink-0 mt-1">


### PR DESCRIPTION
## Summary
- ensure activity feed uses stable unique keys to prevent rendering issues

## Testing
- `npm test` *(fails: sessionStore.setExportError is not a function)*
- `npx vitest run src/components/__tests__/ProgressTracker.test.js` *(fails: Cannot read properties of undefined (reading 'employee_id'))*

------
https://chatgpt.com/codex/tasks/task_b_68bb7cded13c83229cda874a241ad295